### PR TITLE
Allow to set revision mode

### DIFF
--- a/templates/etc/etcd/etcd.yml.erb
+++ b/templates/etc/etcd/etcd.yml.erb
@@ -90,11 +90,10 @@ strict-reconfig-check: <%= scope['etcd::strict_reconfig_check'] %>
 <%# Add support for etcd > v3.3 : Changed value type of etcd --auto-compaction-retention flag to string  -%>
 <% if scope['etcd::auto_compaction_retention'].is_a? String  -%>
 auto-compaction-retention: "<%= scope['etcd::auto_compaction_retention'] %>"
-auto-compaction-mode: <%= scope['etcd::auto_compaction_mode'] %>
 <% else -%>
 auto-compaction-retention: <%= scope['etcd::auto_compaction_retention'] %>
-auto-compaction-mode: <%= scope['etcd::auto_compaction_mode'] %>
 <% end -%>
+auto-compaction-mode: <%= scope['etcd::auto_compaction_mode'] %>
 
 # Force to create a new one member cluster.
 force-new-cluster: false

--- a/templates/etc/etcd/etcd.yml.erb
+++ b/templates/etc/etcd/etcd.yml.erb
@@ -93,6 +93,7 @@ auto-compaction-retention: "<%= scope['etcd::auto_compaction_retention'] %>"
 auto-compaction-mode: <%= scope['etcd::auto_compaction_mode'] %>
 <% else -%>
 auto-compaction-retention: <%= scope['etcd::auto_compaction_retention'] %>
+auto-compaction-mode: <%= scope['etcd::auto_compaction_mode'] %>
 <% end -%>
 
 # Force to create a new one member cluster.


### PR DESCRIPTION
We need to be able to set the mode for non-string retentions as the default mode (in etcd as well as in this module) is "periodic".

no-op on old clusters:
```
exoadmin@kube-registry001:~$ sudo puppet agent -t --environment sebastian --noop
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for kube-registry001.gv2.p.exoscale.net
Info: Applying configuration version '1613488648'
Notice: Finished catalog run in 7.03 seconds
```

Allows to set different mode with non-string retention on new clusters:
```
root@kube-registry-lab005:/etc/puppet# puppet agent -t --environment sebastian --noop
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for kube-registry-lab005.gv2.p.exoscale.net
Info: Applying configuration version '1613488600'
Notice: /Stage[main]/Etcd::Config/File[/etc/default/etcd]/content: 
--- /etc/default/etcd   2020-11-25 15:18:27.509771632 +0000
+++ /tmp/puppet-file20210216-3713698-su5pjq     2021-02-16 15:17:01.050438689 +0000
@@ -30,7 +30,7 @@
 ETCD_INITIAL_CLUSTER_TOKEN="kube-gva2-lab-2"
 ETCD_DISCOVERY_FALLBACK="proxy"
 ETCD_STRICT_RECONFIG_CHECK=false
-ETCD_AUTO_COMPACTION_RETENTION=3h
+ETCD_AUTO_COMPACTION_RETENTION=1000
 ETCD_FORCE_NEW_CLUSTER=false
 #
 

Notice: /Stage[main]/Etcd::Config/File[/etc/default/etcd]/content: current_value {md5}3663ffdd147a948f92ca9942488ad27d, should be {md5}14da9f0d021a8a022bdd8b674fb81f46 (noop)
Notice: /Stage[main]/Etcd::Config/File[/etc/etcd/etcd.yml]/content: 
--- /etc/etcd/etcd.yml  2021-02-08 15:18:29.285826289 +0000
+++ /tmp/puppet-file20210216-3713698-fowafy     2021-02-16 15:17:01.070438542 +0000
@@ -62,8 +62,8 @@
 strict-reconfig-check: false
 
 # Auto compaction retention for mvcc key value store in hour. 0 means disable it.
-auto-compaction-retention: "3h"
-auto-compaction-mode: periodic
+auto-compaction-retention: "1000"
+auto-compaction-mode: revision
 
 # Force to create a new one member cluster.
 force-new-cluster: false

Notice: /Stage[main]/Etcd::Config/File[/etc/etcd/etcd.yml]/content: current_value {md5}b3eca156b677a7efd1fd62383c9f7f31, should be {md5}3b31c14e25354c5ccfd3a3985d5020b9 (noop)
Notice: Class[Etcd::Config]: Would have triggered 'refresh' from 2 events
Info: Class[Etcd::Config]: Scheduling refresh of Class[Etcd::Service]
Notice: Class[Etcd::Service]: Would have triggered 'refresh' from 1 events
Notice: Class[Etcd]: Would have triggered 'refresh' from 1 events
Info: Class[Etcd]: Scheduling refresh of Exec[etcd-reload]
Notice: /Stage[main]/Kubernetes2::Registry::Service/Exec[etcd-reload]: Would have triggered 'refresh' from 1 events
Notice: Class[Kubernetes2::Registry::Service]: Would have triggered 'refresh' from 1 events
Notice: Stage[main]: Would have triggered 'refresh' from 3 events
Notice: Finished catalog run in 8.12 seconds
```